### PR TITLE
Build Executables using GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,10 +33,11 @@ jobs:
         path: dist_electron/*.exe
 
     - uses: actions/upload-artifact@v2
-      if: runner.os == 'Linux'
+      if: runner.os == 'linux'
       with:
         name: ${{ matrix.os }}-executables.zip
         path: dist_electron/*.AppImage
+
     - uses: actions/upload-artifact@v2
       if: runner.os == 'macos'
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,34 +1,37 @@
-name: Node.js CI
+name: Build Executables
 
 on:
   push:
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
-
     strategy:
       matrix:
-        node-version: [ 12.x]
         os: [windows-latest,ubuntu-latest,macos-latest]
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
+
+    - name: Use Node.js 12.x
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ matrix.node-version }}
-    - name: INstall Yarn
+        node-version: 12.x
+
+    - name: Install Yarn
       run: npm install -g yarn
+
     - name: Install deps
-      run: |
-        yarn install
-        yarn electron:build
+      run: yarn install
+
+    - name: Build Executables
+      run: yarn electron:build
+        
     - uses: actions/upload-artifact@v2
       if: runner.os == 'windows'
       with:
         name: dist
         path: dist_electron/*.exe
+
     - uses: actions/upload-artifact@v2
       with:
         name: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,10 +29,10 @@ jobs:
     - uses: actions/upload-artifact@v2
       if: runner.os == 'windows'
       with:
-        name: dist
+        name: ${{ matrix.os }}-executables.zip
         path: dist_electron/*.exe
 
     - uses: actions/upload-artifact@v2
       with:
-        name: dist
+        name: ${{ matrix.os }}-executables.zip
         path: dist_electron/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,9 @@ jobs:
       run: yarn install
 
     - name: Build Executables
-      run: yarn electron:build
+      run: |
+        yarn electron:build
+        ls dist_electron
         
     - uses: actions/upload-artifact@v2
       if: runner.os == 'windows'
@@ -33,6 +35,12 @@ jobs:
         path: dist_electron/*.exe
 
     - uses: actions/upload-artifact@v2
+      if: runner.os == 'ubuntu'
+      with:
+        name: ${{ matrix.os }}-executables.zip
+        path: dist_electron/*.AppImage
+    - uses: actions/upload-artifact@v2
+      if: runner.os == 'macos'
       with:
         name: ${{ matrix.os }}-executables.zip
         path: dist_electron/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,7 @@ jobs:
       run: yarn install
 
     - name: Build Executables
-      run: |
-        yarn electron:build
-        ls dist_electron
+      run: yarn electron:build
         
     - uses: actions/upload-artifact@v2
       if: runner.os == 'windows'
@@ -43,4 +41,4 @@ jobs:
       if: runner.os == 'macos'
       with:
         name: ${{ matrix.os }}-executables.zip
-        path: dist_electron/*
+        path: dist_electron/*.dmg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         path: dist_electron/*.exe
 
     - uses: actions/upload-artifact@v2
-      if: runner.os == 'ubuntu'
+      if: runner.os == 'Linux'
       with:
         name: ${{ matrix.os }}-executables.zip
         path: dist_electron/*.AppImage

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,30 @@
+name: Node.js CI
+
+on:
+  push:
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        node-version: [ 12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: INstall Yarn
+      run: npm install -g yarn
+    - name: Install deps
+      run: |
+        yarn install
+        yarn electron:build
+    - uses: actions/upload-artifact@v2
+      with:
+        name: dist
+        path: dist_electron

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,4 +27,4 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: dist
-        path: dist_electron
+        path: dist_electron/*.exe

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -6,12 +6,12 @@ on:
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         node-version: [ 12.x]
-
+        os: [windows-latest,ubuntu-latest,macos-latest]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
@@ -25,6 +25,11 @@ jobs:
         yarn install
         yarn electron:build
     - uses: actions/upload-artifact@v2
+      if: runner.os == 'windows'
       with:
         name: dist
         path: dist_electron/*.exe
+    - uses: actions/upload-artifact@v2
+      with:
+        name: dist
+        path: dist_electron/*


### PR DESCRIPTION
This is for ease of users to download and install the build artificial rather then building themselves ( they may not have build tools).