### PR TITLE
Change hot reload to work on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **On Linux** The zip file will contain a .AppImage file. Before running the file you'll have to mark it as executable with `chmod +x manim-renderer-<version>.AppImage`.
 
-**On Windows 10** The zip file will contain an application installer. When you run it you'll see a window saying that the app is unrecognized. Verifying software on Windows requires paying around $100 annually for a certificate, so we've opted not to do it. You can still run the renderer by clicking "More info" and "Run anyway" in the dialog. Automatic reloading doesn't work on Windows [due to the way its filesystem works](https://github.com/gorakhargosh/watchdog/issues/393).
+**On Windows 10** The zip file will contain an application installer. When you run it you'll see a window saying that the app is unrecognized. Verifying software on Windows requires paying around $100 annually for a certificate, so we've opted not to do it. You can still run the renderer by clicking "More info" and "Run anyway" in the dialog.
 
 ## To develop
 * Install dependencies: `yarn install`

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@grpc/grpc-js": "^1.0.5",
     "@grpc/proto-loader": "^0.5.4",
     "@mdi/font": "^5.3.45",
+    "chokidar": "^3.5.1",
     "core-js": "^3.6.5",
     "eslint-plugin-vue": "^6.2.2",
     "google-auth-library": "^6.0.1",

--- a/public/proto/frameserver.proto
+++ b/public/proto/frameserver.proto
@@ -9,7 +9,7 @@ service FrameServer {
     // Returns a list of the names and durations of all animations in the scene.
     rpc FetchSceneData (EmptyRequest) returns (FetchSceneDataResponse);
     
-    // Returns when the Manim script changes
+    // Called when the Manim script changes
     rpc ScriptUpdated (EmptyRequest) returns (EmptyResponse);
 }
 

--- a/public/proto/frameserver.proto
+++ b/public/proto/frameserver.proto
@@ -8,10 +8,14 @@ service FrameServer {
 
     // Returns a list of the names and durations of all animations in the scene.
     rpc FetchSceneData (EmptyRequest) returns (FetchSceneDataResponse);
+    
+    // Returns when the Manim script changes
+    rpc ScriptUpdated (EmptyRequest) returns (EmptyResponse);
 }
 
 message FetchSceneDataResponse {
     Scene scene = 1;
+    string path = 2;
 }
 
 message Scene {

--- a/src/App.vue
+++ b/src/App.vue
@@ -102,7 +102,7 @@ import * as utils from "./utils.js";
 import Timeline from "./Timeline.vue";
 import DebugCard from "./DebugCard.vue";
 
-const fs = require("fs");
+const chokidar = require("chokidar");
 const path = require("path");
 const grpc = require("@grpc/grpc-js");
 const protoLoader = require("@grpc/proto-loader");
@@ -215,7 +215,7 @@ export default {
         console.error(error);
         return;
       }
-      fs.watchFile(response.path, {interval: 1000}, () => {
+      chokidar.watch(response.path).on('all', () => {
         this.frameClient.scriptUpdated({}, (err, res) => {
           if (err) {
             console.error(err);

--- a/src/App.vue
+++ b/src/App.vue
@@ -219,7 +219,7 @@ export default {
         this.frameClient.scriptUpdated({}, (err, res) => {
           if (err) {
             console.error(err);
-            return;
+            // return;
           }
         });
       });

--- a/src/App.vue
+++ b/src/App.vue
@@ -102,6 +102,7 @@ import * as utils from "./utils.js";
 import Timeline from "./Timeline.vue";
 import DebugCard from "./DebugCard.vue";
 
+const fs = require("fs");
 const path = require("path");
 const grpc = require("@grpc/grpc-js");
 const protoLoader = require("@grpc/proto-loader");
@@ -209,11 +210,19 @@ export default {
     this.idleRender();
 
     // Request startup information from Manim.
-    this.frameClient.fetchSceneData({}, (err, response) => {
-      if (err) {
-        console.error(err);
+    this.frameClient.fetchSceneData({}, (error, response) => {
+      if (error) {
+        console.error(error);
         return;
       }
+      fs.watchFile(response.path, {interval: 1000}, () => {
+        this.frameClient.scriptUpdated({}, (err, res) => {
+          if (err) {
+            console.error(err);
+            return;
+          }
+        });
+      });
       this.updateSceneData(response);
     });
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2566,6 +2566,21 @@ chokidar@^2.1.8:
   optionalDependencies:
     fsevents "^1.2.7"
 
+chokidar@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
+  integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.5.0"
+  optionalDependencies:
+    fsevents "~2.3.1"
+
 chownr@^1.1.1, chownr@^1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"


### PR DESCRIPTION
This change makes JS watch for script changes rather than Python, then requests an update. While indirect, it works on Windows (which the current implementation does not). Sometimes the renderer requires a restart initially to get the hot reload working.